### PR TITLE
fix: support wayland in nix dev shell

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -15,6 +15,7 @@
       let
         overlays = [ rust-overlay.overlays.default ];
         pkgs = import nixpkgs { inherit system overlays; };
+        lib = pkgs.lib;
         rust = pkgs.rust-bin.fromRustupToolchainFile ./rust-toolchain.toml;
         inputs = [
           rust
@@ -57,8 +58,15 @@
         };
 
 
-        devShell = pkgs.mkShell {
+        devShell = pkgs.mkShell rec {
           packages = inputs;
+          buildInputs = with pkgs; [
+            libxkbcommon
+            libGL
+            # WINIT_UNIX_BACKEND=wayland
+            wayland
+          ];
+          LD_LIBRARY_PATH = "${lib.makeLibraryPath buildInputs}";
           shellHook = ''
             export LIBCLANG_PATH=${pkgs.libclang.lib}/lib/
             export LD_LIBRARY_PATH=${pkgs.openssl}/lib:$LD_LIBRARY_PATH


### PR DESCRIPTION
iced wants to load a dynamic library for wayland, which doesn't work on nix if it's not explicitly put into the path. See: https://github.com/rust-windowing/winit/issues/3244#issuecomment-1827827667

There's probably a more idiomatic way to go about it, but this is what made it work for me, so I thought I might post it. You might need to add more libraries for X support on Nix.