### PR TITLE
Add calling setup_db function to create database if it doesn't exist

### DIFF
--- a/src/core.rs
+++ b/src/core.rs
@@ -394,7 +394,7 @@ pub fn run_core() -> Subscription<Message> {
 
                         let db_path = db_path.to_str().unwrap().to_string();
 
-                        // if the db file doesn't exist, call setup_db
+                        // if the db file doesn't exist, dont call check_password
                         if !std::path::Path::new(&db_path).exists() {
                             info!("Database does not exist, it will be created");
                         } else {

--- a/src/core.rs
+++ b/src/core.rs
@@ -393,6 +393,14 @@ pub fn run_core() -> Subscription<Message> {
                         let db_path = path.join("harbor.sqlite");
 
                         let db_path = db_path.to_str().unwrap().to_string();
+
+                        // if the db file doesn't exist, call setup_db
+                        if !std::path::Path::new(&db_path).exists() {
+                            if let Err(e) = setup_db(&db_path, password.clone()) {
+                                error!("error setting up db: {e}");
+                            }
+                        }
+
                         if let Err(e) = check_password(&db_path, &password) {
                             // probably invalid password
                             error!("error using password: {e}");


### PR DESCRIPTION
This PR fixes when starting the app; the database is never created.

**Test Plan**
running ```just run```, the app starts correctly; if no database file exists, it is created after entering a password.
If the database already exists and the wrong password is entered, the app shows an "invalid password" message.