### PR TITLE
include assets in build

### DIFF
--- a/src/components/icon.rs
+++ b/src/components/icon.rs
@@ -1,4 +1,7 @@
-use iced::{widget::Svg, Theme};
+use iced::{
+    widget::{svg::Handle, Svg},
+    Theme,
+};
 
 pub enum SvgIcon {
     ChevronDown,
@@ -19,25 +22,42 @@ pub enum SvgIcon {
     Chain,
 }
 
+macro_rules! icon_handle {
+    ($icon:expr) => {
+        Svg::new(Handle::from_memory(include_bytes!(concat!(
+            "../../assets/icons/",
+            $icon
+        ))))
+    };
+}
+
 pub fn map_icon<'a>(icon: SvgIcon, width: f32, height: f32) -> Svg<'a, Theme> {
     match icon {
-        SvgIcon::ChevronDown => Svg::from_path("assets/icons/chevron_down.svg"),
-        SvgIcon::DownLeft => Svg::from_path("assets/icons/down_left.svg"),
-        SvgIcon::Heart => Svg::from_path("assets/icons/heart.svg"),
-        SvgIcon::Home => Svg::from_path("assets/icons/home.svg"),
-        SvgIcon::LeftRight => Svg::from_path("assets/icons/left_right.svg"),
-        SvgIcon::People => Svg::from_path("assets/icons/people.svg"),
-        SvgIcon::Settings => Svg::from_path("assets/icons/settings.svg"),
-        SvgIcon::Squirrel => Svg::from_path("assets/icons/squirrel.svg"),
-        SvgIcon::UpRight => Svg::from_path("assets/icons/up_right.svg"),
-        SvgIcon::Copy => Svg::from_path("assets/icons/copy.svg"),
-        SvgIcon::Plus => Svg::from_path("assets/icons/plus.svg"),
-        SvgIcon::Qr => Svg::from_path("assets/icons/qr.svg"),
-        SvgIcon::Restart => Svg::from_path("assets/icons/restart.svg"),
-        SvgIcon::SmallClose => Svg::from_path("assets/icons/small_close.svg"),
-        SvgIcon::Bolt => Svg::from_path("assets/icons/bolt.svg"),
-        SvgIcon::Chain => Svg::from_path("assets/icons/chain.svg"),
+        SvgIcon::ChevronDown => icon_handle!("chevron_down.svg"),
+        SvgIcon::DownLeft => icon_handle!("down_left.svg"),
+        SvgIcon::Heart => icon_handle!("heart.svg"),
+        SvgIcon::Home => icon_handle!("home.svg"),
+        SvgIcon::LeftRight => icon_handle!("left_right.svg"),
+        SvgIcon::People => icon_handle!("people.svg"),
+        SvgIcon::Settings => icon_handle!("settings.svg"),
+        SvgIcon::Squirrel => icon_handle!("squirrel.svg"),
+        SvgIcon::UpRight => icon_handle!("up_right.svg"),
+        SvgIcon::Copy => icon_handle!("copy.svg"),
+        SvgIcon::Plus => icon_handle!("plus.svg"),
+        SvgIcon::Qr => icon_handle!("qr.svg"),
+        SvgIcon::Restart => icon_handle!("restart.svg"),
+        SvgIcon::SmallClose => icon_handle!("small_close.svg"),
+        SvgIcon::Bolt => icon_handle!("bolt.svg"),
+        SvgIcon::Chain => icon_handle!("chain.svg"),
     }
     .width(width)
     .height(height)
+}
+
+pub fn harbor_logo() -> Svg<'static, Theme> {
+    Svg::new(Handle::from_memory(include_bytes!(
+        "../../assets/harbor_logo.svg"
+    )))
+    .width(167)
+    .height(61)
 }

--- a/src/components/sidebar.rs
+++ b/src/components/sidebar.rs
@@ -1,19 +1,17 @@
 use crate::components::SvgIcon;
 use iced::widget::container::Style;
-use iced::widget::{column, container, vertical_space, Svg};
+use iced::widget::{column, container, vertical_space};
 use iced::Border;
 use iced::{Alignment, Element, Shadow};
 
 use crate::{HarborWallet, Message, Route};
 
-use super::{lighten, sidebar_button};
+use super::{harbor_logo, lighten, sidebar_button};
 
 pub fn sidebar(harbor: &HarborWallet) -> Element<Message> {
     let sidebar = container(
         column![
-            Svg::from_path("assets/harbor_logo.svg")
-                .width(167)
-                .height(61),
+            harbor_logo(),
             sidebar_button("Home", SvgIcon::Home, Route::Home, harbor.active_route)
                 .on_press(Message::Navigate(Route::Home)),
             sidebar_button("Mints", SvgIcon::People, Route::Mints, harbor.active_route)

--- a/src/routes/unlock.rs
+++ b/src/routes/unlock.rs
@@ -1,9 +1,9 @@
 use crate::{
-    components::{h_button, h_input, SvgIcon},
+    components::{h_button, h_input, harbor_logo, SvgIcon},
     UnlockStatus,
 };
 use iced::{
-    widget::{center, column, container, text, Svg},
+    widget::{center, column, container, text},
     Color,
 };
 use iced::{Alignment, Element, Length};
@@ -36,11 +36,7 @@ pub fn unlock(harbor: &HarborWallet) -> Element<Message> {
         None,
     );
 
-    let harbor_logo = Svg::from_path("assets/harbor_logo.svg")
-        .width(167)
-        .height(61);
-
-    let page_column = column![harbor_logo, password_input, unlock_button,]
+    let page_column = column![harbor_logo(), password_input, unlock_button,]
         .spacing(32)
         .align_items(Alignment::Center)
         .width(Length::Fixed(256.));


### PR DESCRIPTION
should close #76 

I'm sure it's theoretically possible we could have an output "folder" for builds and that's what we distribute, but these assets are small and for now it's a lot cleaner to just add them to the binary